### PR TITLE
correct date and location in SEO tag

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: BioC 2020
 description:
     Where Software and Biology Connect.<br />
-    June 24 - 27, New York City, USA.
+    July 29 - 31, Boston, USA.
 theme: jekyll-theme-minimal


### PR DESCRIPTION
The 'SEO' tag has the 2019 date and location on all pages; this updates to the correct date and location

See https://community-bioc.slack.com/archives/C35G93GJH/p1582064763229700